### PR TITLE
refactor: implement three-service architecture for update system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,54 @@
-BIN := update-service
+SERVICES := update-service update-fetcher update-installer
 GIT_REV := $(shell git describe --tags --always 2>/dev/null)
 ifdef GIT_REV
-LDFLAGS := -X main.version=$(GIT_REV)
+LDFLAGS := -X main.Version=$(GIT_REV)
 else
 LDFLAGS :=
 endif
 BUILDFLAGS := -tags netgo,osusergo
-MAIN := ./cmd/update-service
 
 .PHONY: build host arm amd64 dist clean test fmt tidy all run run-dev
 
 build: host
-host:
-	go build -ldflags "$(LDFLAGS)" -o ${BIN}-host ${MAIN}
 
-amd64:
-	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" $(BUILDFLAGS) -o ${BIN}-amd64 ${MAIN}
+host: $(SERVICES:%=%-host)
 
-arm:
-	GOOS=linux GOARCH=arm GOARM=7 go build -ldflags "$(LDFLAGS)" $(BUILDFLAGS) -o ${BIN}-arm ${MAIN}
+amd64: $(SERVICES:%=%-amd64)
 
-dist:
-	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS) -s -w" $(BUILDFLAGS) -o ${BIN}-arm-dist ${MAIN}
+arm: $(SERVICES:%=%-arm)
+
+dist: $(SERVICES:%=%-arm-dist)
+
+%-host:
+	go build -ldflags "$(LDFLAGS)" -o $@ ./cmd/$(subst -host,,$@)
+
+%-amd64:
+	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" $(BUILDFLAGS) -o $@ ./cmd/$(subst -amd64,,$@)
+
+%-arm:
+	GOOS=linux GOARCH=arm GOARM=7 go build -ldflags "$(LDFLAGS)" $(BUILDFLAGS) -o $@ ./cmd/$(subst -arm,,$@)
+
+%-arm-dist:
+	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS) -s -w" $(BUILDFLAGS) -o $@ ./cmd/$(subst -arm-dist,,$@)
 
 clean:
-	rm -f ${BIN} ${BIN}-host ${BIN}-amd64 ${BIN}-arm ${BIN}-arm-dist
+	rm -f $(SERVICES) $(SERVICES:%=%-host) $(SERVICES:%=%-amd64) $(SERVICES:%=%-arm) $(SERVICES:%=%-arm-dist)
 
 # Run the service
 run: host
-	./${BIN}-host
+	./update-service-host
 
 # Run with shorter check interval for development
 run-dev: host
-	./${BIN}-host -check-interval=1m -default-channel=nightly -dry-run
+	./update-service-host -check-interval=1m -default-channel=nightly -dry-run
+
+# Run fetcher service
+run-fetcher: host
+	./update-fetcher-host
+
+# Run installer service  
+run-installer: host
+	./update-installer-host -update-key=mender/update/mdb/url -component=mdb
 
 # Run tests
 test:

--- a/cmd/update-fetcher/main.go
+++ b/cmd/update-fetcher/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/librescoot/update-service/pkg/config"
+	"github.com/librescoot/update-service/pkg/download"
+	"github.com/librescoot/update-service/pkg/redis"
+)
+
+type FetchRequest struct {
+	URL      string `json:"url"`
+	ReplyTo  string `json:"reply_to"`
+	Checksum string `json:"checksum,omitempty"`
+}
+
+type FetchResponse struct {
+	Success   bool   `json:"success"`
+	FilePath  string `json:"file_path,omitempty"`
+	Error     string `json:"error,omitempty"`
+	RequestID string `json:"request_id"`
+}
+
+func main() {
+	var (
+		redisAddr    = flag.String("redis-addr", "localhost:6379", "Redis server address")
+		redisPass    = flag.String("redis-pass", "", "Redis password")
+		redisDB      = flag.Int("redis-db", 0, "Redis database number")
+		downloadDir  = flag.String("download-dir", "/tmp/updates", "Directory to store downloaded files")
+		queueName    = flag.String("queue", "fetch-requests", "Redis queue name for fetch requests")
+	)
+	flag.Parse()
+
+	log.Printf("Starting update-fetcher service")
+	log.Printf("Redis: %s (DB %d)", *redisAddr, *redisDB)
+	log.Printf("Download directory: %s", *downloadDir)
+	log.Printf("Queue: %s", *queueName)
+
+	cfg := &config.Config{
+		Redis: config.RedisConfig{
+			Addr:     *redisAddr,
+			Password: *redisPass,
+			DB:       *redisDB,
+		},
+	}
+
+	redisClient := redis.NewClient(cfg)
+	if err := redisClient.Connect(); err != nil {
+		log.Fatalf("Failed to connect to Redis: %v", err)
+	}
+	defer redisClient.Close()
+
+	downloadManager := download.NewManager(*downloadDir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle shutdown gracefully
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		log.Println("Received shutdown signal")
+		cancel()
+	}()
+
+	log.Println("Waiting for fetch requests...")
+	
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Shutting down fetcher service")
+			return
+		default:
+			// Block for up to 5 seconds waiting for a request
+			requestData, err := redisClient.BLPop(ctx, 5*time.Second, *queueName)
+			if err != nil {
+				if err == context.Canceled {
+					return
+				}
+				log.Printf("Error popping from queue: %v", err)
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			if requestData == "" {
+				// Timeout, continue to check for shutdown
+				continue
+			}
+
+			var request FetchRequest
+			if err := json.Unmarshal([]byte(requestData), &request); err != nil {
+				log.Printf("Error unmarshaling request: %v", err)
+				continue
+			}
+
+			log.Printf("Processing fetch request for URL: %s", request.URL)
+			
+			response := processFetchRequest(ctx, downloadManager, request)
+			
+			// Send response back if ReplyTo is specified
+			if request.ReplyTo != "" {
+				responseData, _ := json.Marshal(response)
+				if err := redisClient.Publish(request.ReplyTo, string(responseData)); err != nil {
+					log.Printf("Error publishing response: %v", err)
+				}
+			}
+		}
+	}
+}
+
+func processFetchRequest(ctx context.Context, dm *download.Manager, request FetchRequest) FetchResponse {
+	downloadCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+
+	filePath, err := dm.Download(downloadCtx, request.URL)
+	if err != nil {
+		log.Printf("Download failed for %s: %v", request.URL, err)
+		return FetchResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Download failed: %v", err),
+		}
+	}
+
+	// Verify checksum if provided
+	if request.Checksum != "" {
+		if err := dm.VerifyChecksum(filePath, request.Checksum); err != nil {
+			log.Printf("Checksum verification failed for %s: %v", filePath, err)
+			// Clean up the downloaded file
+			os.Remove(filePath)
+			return FetchResponse{
+				Success: false,
+				Error:   fmt.Sprintf("Checksum verification failed: %v", err),
+			}
+		}
+		log.Printf("Checksum verified for %s", filePath)
+	}
+
+	log.Printf("Successfully downloaded %s to %s", request.URL, filePath)
+	return FetchResponse{
+		Success:  true,
+		FilePath: filePath,
+	}
+}

--- a/cmd/update-installer/main.go
+++ b/cmd/update-installer/main.go
@@ -1,0 +1,335 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/librescoot/update-service/pkg/config"
+	"github.com/librescoot/update-service/pkg/mender"
+	"github.com/librescoot/update-service/pkg/redis"
+)
+
+type FetchRequest struct {
+	URL      string `json:"url"`
+	ReplyTo  string `json:"reply_to"`
+	Checksum string `json:"checksum,omitempty"`
+}
+
+type FetchResponse struct {
+	Success   bool   `json:"success"`
+	FilePath  string `json:"file_path,omitempty"`
+	Error     string `json:"error,omitempty"`
+	RequestID string `json:"request_id"`
+}
+
+var Version string
+
+func main() {
+	var (
+		redisAddr    = flag.String("redis-addr", "localhost:6379", "Redis server address")
+		redisPass    = flag.String("redis-pass", "", "Redis password")
+		redisDB      = flag.Int("redis-db", 0, "Redis database number")
+		updateKey    = flag.String("update-key", "", "Redis key to watch for updates (contains URL#checksum)")
+		failureKey   = flag.String("failure-key", "", "Redis key for failure messages")
+		component    = flag.String("component", "", "Component name (dbc/mdb)")
+		updateType   = flag.String("update-type", "non-blocking", "Update type (blocking/non-blocking)")
+		fetchQueue   = flag.String("fetch-queue", "fetch-requests", "Redis queue for fetch requests")
+	)
+	flag.Parse()
+
+	if *updateKey == "" || *component == "" {
+		log.Fatal("update-key and component are required")
+	}
+
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	if Version == "" {
+		Version = "dev"
+	}
+	log.Printf("Update installer %s starting for component %s", Version, *component)
+
+	if err := checkMenderAvailable(); err != nil {
+		log.Fatalf("Error checking mender-update: %v", err)
+	}
+
+	cfg := &config.Config{
+		Redis: config.RedisConfig{
+			Addr:     *redisAddr,
+			Password: *redisPass,
+			DB:       *redisDB,
+		},
+	}
+
+	redisClient := redis.NewClient(cfg)
+	if err := redisClient.Connect(); err != nil {
+		log.Fatalf("Failed to connect to Redis: %v", err)
+	}
+	defer redisClient.Close()
+
+	menderClient := mender.NewClient()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigChan
+		log.Printf("Received signal %v, shutting down...", sig)
+		cancel()
+	}()
+
+	// Set initial status
+	statusKey := fmt.Sprintf("mender/status/%s", *component)
+	updateTypeKey := fmt.Sprintf("mender/update_type/%s", *component)
+	
+	if err := redisClient.HSet(statusKey, "status", "initializing"); err != nil {
+		log.Printf("Error setting initial status: %v", err)
+	}
+	if err := redisClient.HSet(updateTypeKey, "update_type", *updateType); err != nil {
+		log.Printf("Error setting initial update type: %v", err)
+	}
+
+	if err := checkAndCommitUpdate(menderClient); err != nil {
+		log.Printf("Error checking/committing update: %v", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Context canceled, exiting...")
+			if err := redisClient.HSet(statusKey, "status", "unknown"); err != nil {
+				log.Printf("Error setting final status: %v", err)
+			}
+			if err := redisClient.HSet(updateTypeKey, "update_type", "none"); err != nil {
+				log.Printf("Error setting final update type: %v", err)
+			}
+			return
+		default:
+			if err := redisClient.HSet(statusKey, "status", "checking-updates"); err != nil {
+				log.Printf("Error setting status to checking-updates: %v", err)
+			}
+
+			urlAndChecksum, err := waitForUpdate(ctx, redisClient, *updateKey)
+			if err != nil {
+				if err == context.Canceled {
+					return
+				}
+				log.Printf("Error waiting for update: %v", err)
+				if err := redisClient.HSet(statusKey, "status", "checking-update-error"); err != nil {
+					log.Printf("Error setting error status: %v", err)
+				}
+				time.Sleep(5 * time.Second)
+				continue
+			}
+
+			// Parse URL#checksum format
+			parts := strings.Split(urlAndChecksum, "#")
+			url := parts[0]
+			var checksum string
+			if len(parts) > 1 {
+				checksum = parts[1]
+			}
+
+			log.Printf("Received update URL: %s", url)
+			if checksum != "" {
+				log.Printf("Checksum: %s", checksum)
+			}
+
+			if err := handleUpdate(ctx, url, checksum, redisClient, menderClient, *failureKey, statusKey, updateTypeKey, *fetchQueue, *updateType); err != nil {
+				log.Printf("Error handling update: %v", err)
+				status := "unknown"
+				if strings.Contains(err.Error(), "download") {
+					status = "downloading-update-error"
+				} else if strings.Contains(err.Error(), "install") {
+					status = "installing-update-error"
+				}
+				if err := redisClient.HSet(statusKey, "status", status); err != nil {
+					log.Printf("Error setting error status: %v", err)
+				}
+				if *failureKey != "" {
+					if err := redisClient.HSet(*failureKey, "error", err.Error()); err != nil {
+						log.Printf("Error setting failure: %v", err)
+					}
+				}
+			} else {
+				if err := redisClient.HSet(statusKey, "status", "installation-complete-waiting-reboot"); err != nil {
+					log.Printf("Error setting success status: %v", err)
+				}
+				if err := redisClient.HSet(updateTypeKey, "update_type", "none"); err != nil {
+					log.Printf("Error setting update type to none: %v", err)
+				}
+				
+				log.Println("Update installed successfully. Waiting for reboot...")
+				select {
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}
+}
+
+func checkMenderAvailable() error {
+	_, err := exec.LookPath("mender-update")
+	if err != nil {
+		return fmt.Errorf("mender-update not found in PATH: %w", err)
+	}
+	return nil
+}
+
+func checkAndCommitUpdate(menderClient *mender.Client) error {
+	needsCommit, err := menderClient.NeedsCommit()
+	if err != nil {
+		return fmt.Errorf("error checking if update needs commit: %w", err)
+	}
+
+	if needsCommit {
+		log.Println("Update needs to be committed, committing...")
+		if err := menderClient.Commit(); err != nil {
+			return fmt.Errorf("error committing update: %w", err)
+		}
+		log.Println("Update committed successfully")
+	} else {
+		log.Println("No update needs to be committed")
+	}
+
+	return nil
+}
+
+func waitForUpdate(ctx context.Context, redisClient *redis.Client, updateKey string) (string, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+			url, err := redisClient.Get(updateKey)
+			if err != nil {
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			if url != "" {
+				return url, nil
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}
+}
+
+func handleUpdate(
+	ctx context.Context,
+	url, checksum string,
+	redisClient *redis.Client,
+	menderClient *mender.Client,
+	failureKey, statusKey, updateTypeKey string,
+	fetchQueue, updateType string,
+) error {
+	var filePath string
+	
+	// Check if this is a file:// URL
+	if strings.HasPrefix(url, "file://") {
+		filePath = strings.TrimPrefix(url, "file://")
+		log.Printf("Using local file: %s", filePath)
+	} else {
+		// Use fetcher service for downloads
+		if err := redisClient.HSet(statusKey, "status", "downloading-updates"); err != nil {
+			log.Printf("Error setting status to downloading-updates: %v", err)
+		}
+
+		var err error
+		filePath, err = requestDownload(ctx, redisClient, url, checksum, fetchQueue)
+		if err != nil {
+			if err := redisClient.HSet(statusKey, "status", "downloading-update-error"); err != nil {
+				log.Printf("Error setting status to downloading-update-error: %v", err)
+			}
+			return fmt.Errorf("error downloading update: %w", err)
+		}
+		log.Printf("Downloaded update to: %s", filePath)
+	}
+
+	log.Println("Installing update...")
+	if err := redisClient.HSet(statusKey, "status", "installing-updates"); err != nil {
+		log.Printf("Error setting status to installing-updates: %v", err)
+	}
+
+	if err := menderClient.Install(filePath); err != nil {
+		// Clean up downloaded file on error
+		if !strings.HasPrefix(url, "file://") {
+			os.Remove(filePath)
+		}
+		if err := redisClient.HSet(statusKey, "status", "installing-update-error"); err != nil {
+			log.Printf("Error setting status to installing-update-error: %v", err)
+		}
+		return fmt.Errorf("error installing update: %w", err)
+	}
+	log.Println("Update installed successfully")
+
+	// Clean up downloaded file after successful install
+	if !strings.HasPrefix(url, "file://") {
+		if err := os.Remove(filePath); err != nil {
+			log.Printf("Warning: Failed to remove downloaded file %s: %v", filePath, err)
+		}
+	}
+
+	// Set final success status based on update type
+	successStatus := "installation-complete-waiting-reboot"
+	if updateType == "blocking" {
+		successStatus = "installation-complete-waiting-dashboard-reboot"
+	}
+	if err := redisClient.HSet(statusKey, "status", successStatus); err != nil {
+		log.Printf("Error setting final success status: %v", err)
+	}
+
+	return nil
+}
+
+func requestDownload(ctx context.Context, redisClient *redis.Client, url, checksum, fetchQueue string) (string, error) {
+	
+	// Create unique reply channel
+	replyChannel := fmt.Sprintf("fetch-reply-%d", time.Now().UnixNano())
+	
+	// Create fetch request
+	request := FetchRequest{
+		URL:     url,
+		ReplyTo: replyChannel,
+		Checksum: checksum,
+	}
+	
+	requestData, err := json.Marshal(request)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling fetch request: %w", err)
+	}
+	
+	// Send request to fetcher
+	if err := redisClient.RPush(fetchQueue, string(requestData)); err != nil {
+		return "", fmt.Errorf("error sending fetch request: %w", err)
+	}
+	
+	// Wait for response with timeout
+	responseCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	
+	responseData, err := redisClient.BLPop(responseCtx, 30*time.Minute, replyChannel)
+	if err != nil {
+		return "", fmt.Errorf("error waiting for fetch response: %w", err)
+	}
+	
+	var response FetchResponse
+	if err := json.Unmarshal([]byte(responseData), &response); err != nil {
+		return "", fmt.Errorf("error unmarshaling fetch response: %w", err)
+	}
+	
+	if !response.Success {
+		return "", fmt.Errorf("fetch failed: %s", response.Error)
+	}
+	
+	return response.FilePath, nil
+}

--- a/cmd/update-service/main.go
+++ b/cmd/update-service/main.go
@@ -23,10 +23,8 @@ var (
 	checkInterval     = flag.Duration("check-interval", 1*time.Hour, "Interval between update checks")
 	defaultChannel    = flag.String("default-channel", "stable", "Default update channel (stable, testing, nightly)")
 	components        = flag.String("components", "dbc,mdb", "Comma-separated list of components to check for updates")
-	dbcUpdateKey      = flag.String("dbc-update-key", "mender/update/dbc/url", "Redis key for DBC update URLs")
-	mdbUpdateKey      = flag.String("mdb-update-key", "mender/update/mdb/url", "Redis key for MDB update URLs")
-	dbcChecksumKey    = flag.String("dbc-checksum-key", "mender/update/dbc/checksum", "Redis key for DBC update checksums")
-	mdbChecksumKey    = flag.String("mdb-checksum-key", "mender/update/mdb/checksum", "Redis key for MDB update checksums")
+	dbcUpdateKey      = flag.String("dbc-update-key", "update:install:dbc", "Redis key for DBC updates (URL#checksum)")
+	mdbUpdateKey      = flag.String("mdb-update-key", "update:install:mdb", "Redis key for MDB updates (URL#checksum)")
 	dryRun            = flag.Bool("dry-run", false, "If true, don't actually reboot, just notify")
 )
 
@@ -59,8 +57,6 @@ func main() {
 		*components,
 		*dbcUpdateKey,
 		*mdbUpdateKey,
-		*dbcChecksumKey,
-		*mdbChecksumKey,
 		*dryRun,
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/librescoot/update-service
 
-go 1.22.1
+go 1.22.2
+
+toolchain go1.24.1
 
 require github.com/redis/go-redis/v9 v9.8.0
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,11 +27,9 @@ type Config struct {
 	// Component configuration
 	Components []string // "dbc", "mdb"
 
-	// SMUT configuration
-	DbcUpdateKey   string // "mender/update/dbc/url"
-	MdbUpdateKey   string // "mender/update/mdb/url"
-	DbcChecksumKey string // "mender/update/dbc/checksum"
-	MdbChecksumKey string // "mender/update/mdb/checksum"
+	// Update configuration
+	DbcUpdateKey string // "update:install:dbc" (contains URL#checksum)
+	MdbUpdateKey string // "update:install:mdb" (contains URL#checksum)
 
 	// Update constraints
 	MdbRebootCheckInterval time.Duration // How often to check if MDB can be rebooted
@@ -50,8 +48,6 @@ func New(
 	componentsStr string,
 	dbcUpdateKey string,
 	mdbUpdateKey string,
-	dbcChecksumKey string,
-	mdbChecksumKey string,
 	dryRun bool,
 ) *Config {
 	// Parse components string into slice
@@ -68,8 +64,6 @@ func New(
 		Components:        components,
 		DbcUpdateKey:      dbcUpdateKey,
 		MdbUpdateKey:      mdbUpdateKey,
-		DbcChecksumKey:    dbcChecksumKey,
-		MdbChecksumKey:    mdbChecksumKey,
 		// Default values for update constraints
 		MdbRebootCheckInterval: 5 * time.Minute,
 		UpdateRetryInterval:    15 * time.Minute,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,10 +13,8 @@ func TestNew(t *testing.T) {
 		1*time.Hour,
 		"stable",
 		"dbc,mdb",
-		"mender/update/dbc/url",
-		"mender/update/mdb/url",
-		"mender/update/dbc/checksum",
-		"mender/update/mdb/checksum",
+		"update:install:dbc",
+		"update:install:mdb",
 		false,
 	)
 
@@ -49,20 +47,12 @@ func TestNew(t *testing.T) {
 		t.Errorf("Expected Components[1] to be 'mdb', got '%s'", cfg.Components[1])
 	}
 
-	if cfg.DbcUpdateKey != "mender/update/dbc/url" {
-		t.Errorf("Expected DbcUpdateKey to be 'mender/update/dbc/url', got '%s'", cfg.DbcUpdateKey)
+	if cfg.DbcUpdateKey != "update:install:dbc" {
+		t.Errorf("Expected DbcUpdateKey to be 'update:install:dbc', got '%s'", cfg.DbcUpdateKey)
 	}
 
-	if cfg.MdbUpdateKey != "mender/update/mdb/url" {
-		t.Errorf("Expected MdbUpdateKey to be 'mender/update/mdb/url', got '%s'", cfg.MdbUpdateKey)
-	}
-
-	if cfg.DbcChecksumKey != "mender/update/dbc/checksum" {
-		t.Errorf("Expected DbcChecksumKey to be 'mender/update/dbc/checksum', got '%s'", cfg.DbcChecksumKey)
-	}
-
-	if cfg.MdbChecksumKey != "mender/update/mdb/checksum" {
-		t.Errorf("Expected MdbChecksumKey to be 'mender/update/mdb/checksum', got '%s'", cfg.MdbChecksumKey)
+	if cfg.MdbUpdateKey != "update:install:mdb" {
+		t.Errorf("Expected MdbUpdateKey to be 'update:install:mdb', got '%s'", cfg.MdbUpdateKey)
 	}
 
 	// Check that the constants are set correctly
@@ -91,10 +81,8 @@ func TestIsValidComponent(t *testing.T) {
 		1*time.Hour,
 		"stable",
 		"dbc,mdb",
-		"mender/update/dbc/url",
-		"mender/update/mdb/url",
-		"mender/update/dbc/checksum",
-		"mender/update/mdb/checksum",
+		"update:install:dbc",
+		"update:install:mdb",
 		false,
 	)
 
@@ -120,10 +108,8 @@ func TestIsValidChannel(t *testing.T) {
 		1*time.Hour,
 		"stable",
 		"dbc,mdb",
-		"mender/update/dbc/url",
-		"mender/update/mdb/url",
-		"mender/update/dbc/checksum",
-		"mender/update/mdb/checksum",
+		"update:install:dbc",
+		"update:install:mdb",
 		false,
 	)
 

--- a/librescoot-update-fetcher.service
+++ b/librescoot-update-fetcher.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Librescoot Update Fetcher Service
+After=network-online.target redis.service
+Wants=network-online.target redis.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/update-fetcher \
+    --redis-addr=192.168.7.1:6379 \
+    --download-dir=/data/ota \
+    --queue=fetch-requests
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/librescoot-update-installer-dbc.service
+++ b/librescoot-update-installer-dbc.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Librescoot Update Installer (DBC)
+After=network.target redis.service
+Wants=redis.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/update-installer \
+    --redis-addr=192.168.7.1:6379 \
+    --update-key=update:install:dbc \
+    --failure-key=update:failure \
+    --component=dbc \
+    --update-type=blocking \
+    --fetch-queue=fetch-requests
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/librescoot-update-installer-mdb.service
+++ b/librescoot-update-installer-mdb.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Librescoot Update Installer (MDB)
+After=network.target redis.service
+Wants=redis.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/update-installer \
+    --redis-addr=192.168.7.1:6379 \
+    --update-key=update:install:mdb \
+    --failure-key=update:failure \
+    --component=mdb \
+    --update-type=non-blocking \
+    --fetch-queue=fetch-requests
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/librescoot-update.service
+++ b/librescoot-update.service
@@ -1,11 +1,16 @@
 [Unit]
-Description=Librescoot Update Service
+Description=Librescoot Update Service (Orchestrator)
 After=network-online.target redis.service
 Wants=network-online.target redis.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/update-service -default-channel nightly
+ExecStart=/usr/bin/update-service \
+    --redis-addr=192.168.7.1:6379 \
+    --default-channel=nightly \
+    --components=dbc,mdb \
+    --dbc-update-key=update:install:dbc \
+    --mdb-update-key=update:install:mdb
 Restart=on-failure
 RestartSec=10
 StandardOutput=journal

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,14 @@
+package config
+
+// Config holds the application configuration
+type Config struct {
+	Redis RedisConfig
+}
+
+// RedisConfig holds Redis connection configuration
+type RedisConfig struct {
+	Addr     string
+	Password string
+	DB       int
+}
+

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -1,0 +1,204 @@
+package download
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type Manager struct {
+	downloadDir string
+}
+
+func NewManager(downloadDir string) *Manager {
+	// Ensure download directory exists
+	if _, err := os.Stat(downloadDir); os.IsNotExist(err) {
+		log.Printf("Download directory %s does not exist, creating it...", downloadDir)
+		if err := os.MkdirAll(downloadDir, 0755); err != nil {
+			log.Printf("Error creating download directory: %v", err)
+		}
+	}
+	
+	return &Manager{
+		downloadDir: downloadDir,
+	}
+}
+
+func (m *Manager) Download(ctx context.Context, url string) (string, error) {
+	filename := filepath.Base(url)
+	if filename == "" || filename == "." {
+		filename = "update.mender"
+	}
+
+	finalPath := filepath.Join(m.downloadDir, filename)
+	downloadTempPath := filepath.Join(m.downloadDir, filename+".tmp")
+
+	fileInfo, err := os.Stat(downloadTempPath)
+	var fileSize int64
+	if err == nil {
+		fileSize = fileInfo.Size()
+		log.Printf("File already exists with size %d bytes, resuming download", fileSize)
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("error checking file: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("error creating request: %w", err)
+	}
+
+	if fileSize > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", fileSize))
+	}
+
+	// Create a custom transport with separate timeouts
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			VerifyConnection: func(cs tls.ConnectionState) error {
+				// Skip certificate time validation
+				return nil
+			},
+		},
+		// Timeout for establishing TCP connections
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		// Timeout for TLS handshake
+		TLSHandshakeTimeout: 30 * time.Second,
+		// Increase idle connections
+		MaxIdleConns:        100,
+		IdleConnTimeout:     90 * time.Second,
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		// No timeout here - we'll handle timeouts through context
+		Timeout: 0,
+	}
+
+	var resp *http.Response
+	maxRetries := 5
+	for i := 0; i < maxRetries; i++ {
+		log.Printf("Starting download attempt %d/%d", i+1, maxRetries)
+		resp, err = client.Do(req)
+		if err == nil {
+			break
+		}
+		log.Printf("Error downloading file (attempt %d/%d): %v", i+1, maxRetries, err)
+		if i < maxRetries-1 {
+			sleepTime := time.Duration(1<<uint(i)) * time.Second
+			log.Printf("Waiting %v before retry...", sleepTime)
+			time.Sleep(sleepTime)
+		}
+	}
+	if err != nil {
+		return "", fmt.Errorf("error downloading file after %d attempts: %w", maxRetries, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var file *os.File
+	if fileSize > 0 && resp.StatusCode == http.StatusPartialContent {
+		file, err = os.OpenFile(downloadTempPath, os.O_APPEND|os.O_WRONLY, 0644)
+		log.Printf("Opened file for append at offset %d", fileSize)
+	} else {
+		file, err = os.Create(downloadTempPath)
+		fileSize = 0
+		log.Printf("Created new file for download")
+	}
+	if err != nil {
+		return "", fmt.Errorf("error opening file: %w", err)
+	}
+	defer file.Close()
+
+	// Increase buffer size to 1MB for faster downloads
+	buffer := make([]byte, 1024*1024)
+	totalRead := fileSize
+	lastProgressReport := time.Now()
+	start := time.Now()
+	
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+			n, err := resp.Body.Read(buffer)
+			if n > 0 {
+				_, writeErr := file.Write(buffer[:n])
+				if writeErr != nil {
+					return "", fmt.Errorf("error writing to file: %w", writeErr)
+				}
+				totalRead += int64(n)
+
+				if time.Since(lastProgressReport) > 5*time.Second {
+					elapsed := time.Since(start)
+					speed := float64(totalRead) / elapsed.Seconds() / 1024 / 1024 // MB/s
+					log.Printf("Downloaded %d bytes (%.2f MB/s)", totalRead, speed)
+					lastProgressReport = time.Now()
+				}
+			}
+			if err != nil {
+				if err == io.EOF {
+					elapsed := time.Since(start)
+					speed := float64(totalRead) / elapsed.Seconds() / 1024 / 1024 // MB/s
+					log.Printf("Download complete, total size: %d bytes, average speed: %.2f MB/s", totalRead, speed)
+					
+					file.Close()
+					if err := os.Rename(downloadTempPath, finalPath); err != nil {
+						return "", fmt.Errorf("error renaming temporary file: %w", err)
+					}
+					log.Printf("Renamed temporary file %s to %s", downloadTempPath, finalPath)
+					
+					return finalPath, nil
+				}
+				return "", fmt.Errorf("error reading response: %w", err)
+			}
+		}
+	}
+}
+
+func (m *Manager) VerifyChecksum(filePath, checksumStr string) error {
+	parts := strings.SplitN(checksumStr, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid checksum format, expected 'algorithm:hash', got '%s'", checksumStr)
+	}
+
+	algorithm := strings.ToLower(parts[0])
+	expectedHash := parts[1]
+
+	if algorithm != "sha256" {
+		return fmt.Errorf("unsupported checksum algorithm: %s", algorithm)
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("error opening file for checksum verification: %w", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return fmt.Errorf("error calculating checksum: %w", err)
+	}
+
+	actualHash := hex.EncodeToString(hash.Sum(nil))
+	if actualHash != expectedHash {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", expectedHash, actualHash)
+	}
+
+	return nil
+}

--- a/pkg/mender/mender.go
+++ b/pkg/mender/mender.go
@@ -1,0 +1,64 @@
+package mender
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os/exec"
+)
+
+type Client struct{}
+
+func NewClient() *Client {
+	return &Client{}
+}
+
+func (c *Client) NeedsCommit() (bool, error) {
+	// cmd := exec.Command("mender-update", "show-artifact")
+	// var stdout, stderr bytes.Buffer
+	// cmd.Stdout = &stdout
+	// cmd.Stderr = &stderr
+
+	// err := cmd.Run()
+	// if err != nil {
+	// 	return false, fmt.Errorf("error running mender-update show-artifact: %w, stderr: %s", err, stderr.String())
+	// }
+
+	// output := stdout.String()
+	// log.Printf("mender-update show-artifact output: %s", output)
+
+	// return strings.Contains(output, "State: pending"), nil
+	return true, nil
+}
+
+func (c *Client) Install(filePath string) error {
+	log.Printf("Installing update from %s", filePath)
+	cmd := exec.Command("mender-update", "install", filePath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("error running mender-update install: %w, stderr: %s", err, stderr.String())
+	}
+
+	log.Printf("mender-update install output: %s", stdout.String())
+	return nil
+}
+
+func (c *Client) Commit() error {
+	log.Printf("Committing update")
+	cmd := exec.Command("mender-update", "commit")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("error running mender-update commit: %w, stderr: %s", err, stderr.String())
+	}
+
+	log.Printf("mender-update commit output: %s", stdout.String())
+	return nil
+}

--- a/pkg/redis/client.go
+++ b/pkg/redis/client.go
@@ -1,0 +1,113 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/librescoot/update-service/pkg/config"
+	"github.com/redis/go-redis/v9"
+)
+
+// Client wraps the Redis client with our specific methods
+type Client struct {
+	client *redis.Client
+}
+
+// NewClient creates a new Redis client
+func NewClient(cfg *config.Config) *Client {
+	client := redis.NewClient(&redis.Options{
+		Addr:     cfg.Redis.Addr,
+		Password: cfg.Redis.Password,
+		DB:       cfg.Redis.DB,
+	})
+
+	return &Client{
+		client: client,
+	}
+}
+
+// Connect tests the connection to Redis
+func (c *Client) Connect() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	
+	_, err := c.client.Ping(ctx).Result()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Redis: %w", err)
+	}
+	return nil
+}
+
+// Close closes the Redis connection
+func (c *Client) Close() error {
+	return c.client.Close()
+}
+
+// Get retrieves a value from Redis
+func (c *Client) Get(key string) (string, error) {
+	ctx := context.Background()
+	val, err := c.client.Get(ctx, key).Result()
+	if err == redis.Nil {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to get key %s: %w", key, err)
+	}
+	return val, nil
+}
+
+// Set stores a value in Redis
+func (c *Client) Set(key, value string) error {
+	ctx := context.Background()
+	err := c.client.Set(ctx, key, value, 0).Err()
+	if err != nil {
+		return fmt.Errorf("failed to set key %s: %w", key, err)
+	}
+	return nil
+}
+
+// HSet stores a field-value pair in a Redis hash
+func (c *Client) HSet(key, field, value string) error {
+	ctx := context.Background()
+	err := c.client.HSet(ctx, key, field, value).Err()
+	if err != nil {
+		return fmt.Errorf("failed to hset %s %s: %w", key, field, err)
+	}
+	return nil
+}
+
+// RPush pushes a value to the right end of a Redis list
+func (c *Client) RPush(key, value string) error {
+	ctx := context.Background()
+	err := c.client.RPush(ctx, key, value).Err()
+	if err != nil {
+		return fmt.Errorf("failed to rpush to %s: %w", key, err)
+	}
+	return nil
+}
+
+// BLPop blocks and pops from the left end of a Redis list
+func (c *Client) BLPop(ctx context.Context, timeout time.Duration, keys ...string) (string, error) {
+	result, err := c.client.BLPop(ctx, timeout, keys...).Result()
+	if err == redis.Nil {
+		return "", nil // Timeout
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to blpop: %w", err)
+	}
+	if len(result) < 2 {
+		return "", fmt.Errorf("unexpected blpop result: %v", result)
+	}
+	return result[1], nil
+}
+
+// Publish publishes a message to a Redis channel
+func (c *Client) Publish(channel, message string) error {
+	ctx := context.Background()
+	err := c.client.Publish(ctx, channel, message).Err()
+	if err != nil {
+		return fmt.Errorf("failed to publish to %s: %w", channel, err)
+	}
+	return nil
+}


### PR DESCRIPTION
see also: https://github.com/librescoot/meta-librescoot/pull/7

- Split functionality into three focused services:
  - update-service: Main orchestrator with GitHub API and HTTP server
  - update-fetcher: Centralized download service with retry/cleanup
  - update-installer: Installer service using fetcher for downloads

- Simplified Redis communication:
  - Use update:install:mdb and update:install:dbc keys
  - Single key contains URL#checksum format
  - Removed separate checksum keys

- Architecture benefits:
  - Eliminated download logic duplication
  - MDB runs full stack (orchestrator, fetcher, installer)
  - DBC runs only installer, using MDB's fetcher via Redis
  - Clean separation of concerns

- Updated build system:
  - Makefile now builds all three services
  - Added systemd service files for each component
  - Maintained ARM cross-compilation support

This refactoring consolidates simple-updater functionality into update-service while creating a maintainable architecture.