### PR TITLE
feat: fetch releases from static index instead of GitHub API

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The service can be configured via command-line flags or Redis settings. CLI flag
 | `--component`           | Component to manage updates for.                                  | `""`                                                           | **Yes** (must be `mdb` or `dbc`) | No (CLI only) |
 | `--redis-addr`          | Redis server address.                                             | `localhost:6379`                                               | No       | No (CLI only) |
 | `--channel`             | Update channel to track.                                          | `nightly`                                                      | No       | Yes |
-| `--github-releases-url` | GitHub Releases API URL for update discovery.                     | `https://api.github.com/repos/librescoot/librescoot/releases`  | No       | Yes |
+| `--releases-url` | Release index base URL for update discovery.                      | `https://downloads.librescoot.org/releases`                    | No       | Yes |
 | `--check-interval`      | Interval between update checks.                                   | `6h`                                                           | No       | Yes |
 | `--dry-run`             | If true, log reboot actions instead of performing them.           | `false`                                                        | No       | Yes |
 
@@ -102,7 +102,7 @@ Settings can be configured per-component in the Redis `settings` hash. The updat
 **Setting Keys:**
 - `updates.{component}.channel` - Update channel (`stable`, `testing`, or `nightly`)
 - `updates.{component}.check-interval` - Check interval (e.g., `6h`, `1h`, `30m`)
-- `updates.{component}.github-releases-url` - GitHub Releases API URL
+- `updates.{component}.releases-url` - Release index base URL
 - `updates.{component}.dry-run` - Dry-run mode (`true` or `false`)
 - `updates.{component}.method` - Update method (`full` or `delta`)
 

--- a/cmd/update-service/main.go
+++ b/cmd/update-service/main.go
@@ -22,7 +22,7 @@ var version = "dev"
 
 var (
 	redisAddr         = flag.String("redis-addr", "localhost:6379", "Redis server address")
-	githubReleasesURL = flag.String("github-releases-url", "https://api.github.com/repos/librescoot/librescoot/releases", "GitHub Releases API URL")
+	releasesURL = flag.String("releases-url", "https://downloads.librescoot.org/releases", "Release index base URL")
 	checkInterval     = flag.Duration("check-interval", 6*time.Hour, "Interval between update checks (use 0 or 'never' to disable)")
 	component         = flag.String("component", "", "Component to manage updates for (mdb or dbc)")
 	channel           = flag.String("channel", "nightly", "Update channel (stable, testing, nightly)")
@@ -88,7 +88,7 @@ func main() {
 	// Track which CLI flags were explicitly set (non-default)
 	cliChannelSet := flag.Lookup("channel").Value.String() != flag.Lookup("channel").DefValue
 	cliCheckIntervalSet := flag.Lookup("check-interval").Value.String() != flag.Lookup("check-interval").DefValue
-	cliGithubURLSet := flag.Lookup("github-releases-url").Value.String() != flag.Lookup("github-releases-url").DefValue
+	cliReleasesURLSet := flag.Lookup("releases-url").Value.String() != flag.Lookup("releases-url").DefValue
 	cliDryRunSet := flag.Lookup("dry-run").Value.String() != flag.Lookup("dry-run").DefValue
 
 	// Detect channel from installed version
@@ -111,7 +111,7 @@ func main() {
 	// Initialize config with CLI flags and detected/default values
 	cfg := config.New(
 		*redisAddr,
-		*githubReleasesURL,
+		*releasesURL,
 		*checkInterval,
 		*component,
 		effectiveChannel,
@@ -127,7 +127,7 @@ func main() {
 	// Save CLI values if they were explicitly set
 	cliChannel := cfg.Channel
 	cliCheckInterval := cfg.CheckInterval
-	cliGithubURL := cfg.GitHubReleasesURL
+	cliReleasesURL := cfg.ReleasesURL
 	cliDryRun := cfg.DryRun
 
 	// Check if channel will come from Redis settings
@@ -150,15 +150,15 @@ func main() {
 	if cliCheckIntervalSet {
 		cfg.CheckInterval = cliCheckInterval
 	}
-	if cliGithubURLSet {
-		cfg.GitHubReleasesURL = cliGithubURL
+	if cliReleasesURLSet {
+		cfg.ReleasesURL = cliReleasesURL
 	}
 	if cliDryRunSet {
 		cfg.DryRun = cliDryRun
 	}
 
 	// Start watching for settings changes in the background
-	go watchSettingsChanges(ctx, redisClient, cfg, logger, cliChannelSet, cliCheckIntervalSet, cliGithubURLSet, cliDryRunSet)
+	go watchSettingsChanges(ctx, redisClient, cfg, logger, cliChannelSet, cliCheckIntervalSet, cliReleasesURLSet, cliDryRunSet)
 
 	// Initialize power inhibitor client
 	inhibitorClient, err := inhibitor.New(*redisAddr, logger)
@@ -224,7 +224,7 @@ func main() {
 }
 
 // watchSettingsChanges monitors Redis for settings changes and applies them to the config
-func watchSettingsChanges(ctx context.Context, redisClient *redis.Client, cfg *config.Config, logger *log.Logger, cliChannelSet, cliCheckIntervalSet, cliGithubURLSet, cliDryRunSet bool) {
+func watchSettingsChanges(ctx context.Context, redisClient *redis.Client, cfg *config.Config, logger *log.Logger, cliChannelSet, cliCheckIntervalSet, cliReleasesURLSet, cliDryRunSet bool) {
 	// Use HashWatcher to monitor settings hash
 	watcher := redisClient.NewSettingsWatcher()
 	watcher.OnAny(func(settingKey, value string) error {
@@ -245,9 +245,9 @@ func watchSettingsChanges(ctx context.Context, redisClient *redis.Client, cfg *c
 					logger.Printf("Ignoring Redis update for check-interval (overridden by CLI flag)")
 					return nil
 				}
-			case "github-releases-url":
-				if cliGithubURLSet {
-					logger.Printf("Ignoring Redis update for github-releases-url (overridden by CLI flag)")
+			case "releases-url":
+				if cliReleasesURLSet {
+					logger.Printf("Ignoring Redis update for releases-url (overridden by CLI flag)")
 					return nil
 				}
 			case "dry-run":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	RedisAddr string
 
 	// GitHub Releases API configuration
-	GitHubReleasesURL string
+	ReleasesURL string
 	CheckInterval     time.Duration
 
 	// Component and channel configuration
@@ -51,7 +51,7 @@ type Config struct {
 // New creates a new Config with the given parameters
 func New(
 	redisAddr string,
-	githubReleasesURL string,
+	releasesURL string,
 	checkInterval time.Duration,
 	component string,
 	channel string,
@@ -68,7 +68,7 @@ func New(
 	}
 	return &Config{
 		RedisAddr:         redisAddr,
-		GitHubReleasesURL: githubReleasesURL,
+		ReleasesURL: releasesURL,
 		CheckInterval:     checkInterval,
 		Component:         component,
 		Channel:           channel,
@@ -149,9 +149,9 @@ func (c *Config) LoadFromRedis(redis RedisSettings) error {
 		}
 	}
 
-	// Load github-releases-url from Redis if available
-	if url, err := redis.HGet(SettingsHashKey, prefix+"github-releases-url"); err == nil && url != "" {
-		c.GitHubReleasesURL = url
+	// Load releases-url from Redis if available
+	if url, err := redis.HGet(SettingsHashKey, prefix+"releases-url"); err == nil && url != "" {
+		c.ReleasesURL = url
 	}
 
 	// Load dry-run from Redis if available
@@ -190,8 +190,8 @@ func (c *Config) ApplyRedisUpdate(key, value string) bool {
 			c.CheckInterval = duration
 			return true
 		}
-	case "github-releases-url":
-		c.GitHubReleasesURL = value
+	case "releases-url":
+		c.ReleasesURL = value
 		return true
 	case "dry-run":
 		if dryRun, err := strconv.ParseBool(value); err == nil {

--- a/internal/updater/github.go
+++ b/internal/updater/github.go
@@ -18,11 +18,11 @@ const (
 	backoffJitter  = 0.2 // 20% jitter
 )
 
-// Asset represents a GitHub release asset
+// Asset represents a release asset
 type Asset struct {
-	Name               string `json:"name"`
-	Size               int64  `json:"size"`
-	BrowserDownloadURL string `json:"browser_download_url"`
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+	URL  string `json:"url"`
 }
 
 // Release represents a GitHub release
@@ -34,10 +34,11 @@ type Release struct {
 	Assets      []Asset   `json:"assets"`
 }
 
-// GitHubAPI handles interactions with the GitHub API
+// GitHubAPI handles fetching release data from a release index
 type GitHubAPI struct {
 	ctx     context.Context
 	baseURL string
+	channel string
 	client  *http.Client
 	logger  Logger
 }
@@ -47,11 +48,12 @@ type Logger interface {
 	Printf(format string, v ...interface{})
 }
 
-// NewGitHubAPI creates a new GitHub API client
-func NewGitHubAPI(ctx context.Context, baseURL string, logger Logger) *GitHubAPI {
+// NewGitHubAPI creates a new release index client
+func NewGitHubAPI(ctx context.Context, baseURL, channel string, logger Logger) *GitHubAPI {
 	return &GitHubAPI{
 		ctx:     ctx,
 		baseURL: baseURL,
+		channel: channel,
 		client:  &http.Client{Timeout: 10 * time.Second},
 		logger:  logger,
 	}
@@ -69,7 +71,9 @@ func (g *GitHubAPI) GetReleases() ([]Release, error) {
 	)
 
 	// Create the request outside the retry loop
-	req, err := http.NewRequestWithContext(g.ctx, "GET", g.baseURL, nil)
+	url := g.baseURL + "/" + g.channel + ".json"
+
+	req, err := http.NewRequestWithContext(g.ctx, "GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -90,7 +90,7 @@ func New(ctx context.Context, cfg *config.Config, redisClient *redis.Client, inh
 		status:      status.NewReporter(redisClient.GetClient(), cfg.Component, logger),
 		bootUpdater: bootUpdater,
 		bootStatus:  bootStatusReporter,
-		githubAPI:   NewGitHubAPI(updaterCtx, cfg.GitHubReleasesURL, logger),
+		githubAPI:   NewGitHubAPI(updaterCtx, cfg.ReleasesURL, cfg.Channel, logger),
 		logger:      logger,
 		ctx:         updaterCtx,
 		cancel:      cancel,
@@ -1073,7 +1073,7 @@ func (u *Updater) checkForUpdates() {
 		// Match assets by variant_id (e.g., "unu-mdb", "unu-dbc", "rpi5")
 		// Asset names should be like: librescoot-{variant_id}-{timestamp}.mender
 		if strings.Contains(asset.Name, variantID) && strings.HasSuffix(asset.Name, ".mender") {
-			assetURL = asset.BrowserDownloadURL
+			assetURL = asset.URL
 			u.logger.Printf("Found matching asset: %s", asset.Name)
 			break
 		}
@@ -1634,7 +1634,7 @@ func (u *Updater) performDeltaUpdate(releases []Release, currentVersion, variant
 		deltaURL := ""
 		for _, asset := range release.Assets {
 			if strings.Contains(asset.Name, variantID) && strings.HasSuffix(asset.Name, ".delta") {
-				deltaURL = asset.BrowserDownloadURL
+				deltaURL = asset.URL
 				break
 			}
 		}
@@ -1762,7 +1762,7 @@ func (u *Updater) performDeltaUpdate(releases []Release, currentVersion, variant
 				deltaURL := ""
 				for _, asset := range release.Assets {
 					if strings.Contains(asset.Name, variantID) && strings.HasSuffix(asset.Name, ".delta") {
-						deltaURL = asset.BrowserDownloadURL
+						deltaURL = asset.URL
 						break
 					}
 				}
@@ -2112,7 +2112,7 @@ func (u *Updater) findDeltaAsset(release Release, variantID string) string {
 		// Asset names should be like: librescoot-{variant_id}-{timestamp}.delta
 		if strings.Contains(asset.Name, variantID) && strings.HasSuffix(asset.Name, ".delta") {
 			u.logger.Printf("Found delta asset: %s", asset.Name)
-			return asset.BrowserDownloadURL
+			return asset.URL
 		}
 	}
 	return ""
@@ -2124,7 +2124,7 @@ func (u *Updater) findMenderAsset(release Release, variantID string) string {
 		// Match mender assets by variant_id
 		if strings.Contains(asset.Name, variantID) && strings.HasSuffix(asset.Name, ".mender") {
 			u.logger.Printf("Found mender asset: %s", asset.Name)
-			return asset.BrowserDownloadURL
+			return asset.URL
 		}
 	}
 	return ""


### PR DESCRIPTION
Switches release discovery from the GitHub Releases API to pre-built per-channel JSON indexes on downloads.librescoot.org.

## Why

The GitHub API returns all releases in one list with a default page size of 30. With daily nightlies, a `testing` channel release older than ~30 days gets crowded out, causing `buildDeltaChain` to fail with "current version not found." The fallback to full update works but means delta updates never happen for less-frequent channels.

Fetching 100 results (`per_page=100`) would fix pagination but costs 1.6MB per check over cellular.

## What changed

- Default releases URL now points to `downloads.librescoot.org/releases/{channel}.json`
- `GetReleases()` fetches only the configured channel's releases (~80KB vs ~775KB)
- Asset field renamed: `browser_download_url` -> `url`
- If `github-releases-url` in Redis still has the old GitHub API URL, it's ignored (custom URLs still work)

The static indexes are generated at release time by downloads.librescoot.org CI, triggered via `repository_dispatch` from the main build pipeline.

## Breaking change

The JSON schema changed (`browser_download_url` -> `url`). This only affects the update service itself, not external consumers.

If `github-releases-url` was manually set in Redis to the old default (`https://api.github.com/repos/librescoot/librescoot/releases`), it will be ignored. Clear it with:
```
redis-cli hdel settings updates.mdb.github-releases-url
redis-cli hdel settings updates.dbc.github-releases-url
```

## Test plan

- [ ] Build for ARM, deploy to deep-blue
- [ ] Verify update check fetches from the new URL
- [ ] Confirm delta chain builds when current version is in the index
- [ ] Confirm fallback to full update when current version has aged out