### PR TITLE
feat(boot): write U-Boot with eMMC boot partition A/B redundancy

### DIFF
--- a/cmd/update-service/main.go
+++ b/cmd/update-service/main.go
@@ -31,7 +31,7 @@ var (
 	showVersion    = flag.Bool("version", false, "Print version and exit")
 	bootUpdate     = flag.Bool("boot-update", false, "Enable boot partition updates")
 	bootMountPoint = flag.String("boot-mount", "/uboot", "Boot partition mount point")
-	bootDevice     = flag.String("boot-device", "", "U-Boot device path (auto-detected from mount if empty)")
+	bootDevice     = flag.String("boot-device", "", "Base eMMC device (e.g. /dev/mmcblk3); auto-detected from mount if empty")
 	bootDTB        = flag.String("boot-dtb", "", "DTB filename (default: librescoot-{component}.dtb)")
 	bootUBootSeek  = flag.Int64("boot-uboot-seek", 2, "512-byte blocks to seek before writing U-Boot")
 )

--- a/cmd/update-service/main.go
+++ b/cmd/update-service/main.go
@@ -21,19 +21,19 @@ import (
 var version = "dev"
 
 var (
-	redisAddr         = flag.String("redis-addr", "localhost:6379", "Redis server address")
-	releasesURL = flag.String("releases-url", "https://downloads.librescoot.org/releases", "Release index base URL")
-	checkInterval     = flag.Duration("check-interval", 6*time.Hour, "Interval between update checks (use 0 or 'never' to disable)")
-	component         = flag.String("component", "", "Component to manage updates for (mdb or dbc)")
-	channel           = flag.String("channel", "nightly", "Update channel (stable, testing, nightly)")
-	downloadDir       = flag.String("download-dir", "", "Download directory for OTA files (default: /data/ota/{component})")
-	dryRun            = flag.Bool("dry-run", false, "If true, don't actually reboot, just notify")
-	showVersion       = flag.Bool("version", false, "Print version and exit")
-	bootUpdate        = flag.Bool("boot-update", false, "Enable boot partition updates")
-	bootMountPoint    = flag.String("boot-mount", "/uboot", "Boot partition mount point")
-	bootDevice        = flag.String("boot-device", "", "U-Boot device path (auto-detected from mount if empty)")
-	bootDTB           = flag.String("boot-dtb", "", "DTB filename (default: librescoot-{component}.dtb)")
-	bootUBootSeek     = flag.Int64("boot-uboot-seek", 2, "512-byte blocks to seek before writing U-Boot")
+	redisAddr      = flag.String("redis-addr", "localhost:6379", "Redis server address")
+	releasesURL    = flag.String("releases-url", "https://downloads.librescoot.org/releases", "Release index base URL")
+	checkInterval  = flag.Duration("check-interval", 6*time.Hour, "Interval between update checks (use 0 or 'never' to disable)")
+	component      = flag.String("component", "", "Component to manage updates for (mdb or dbc)")
+	channel        = flag.String("channel", "nightly", "Update channel (stable, testing, nightly)")
+	downloadDir    = flag.String("download-dir", "", "Download directory for OTA files (default: /data/ota/{component})")
+	dryRun         = flag.Bool("dry-run", false, "If true, don't actually reboot, just notify")
+	showVersion    = flag.Bool("version", false, "Print version and exit")
+	bootUpdate     = flag.Bool("boot-update", false, "Enable boot partition updates")
+	bootMountPoint = flag.String("boot-mount", "/uboot", "Boot partition mount point")
+	bootDevice     = flag.String("boot-device", "", "U-Boot device path (auto-detected from mount if empty)")
+	bootDTB        = flag.String("boot-dtb", "", "DTB filename (default: librescoot-{component}.dtb)")
+	bootUBootSeek  = flag.Int64("boot-uboot-seek", 2, "512-byte blocks to seek before writing U-Boot")
 )
 
 func main() {

--- a/internal/boot/updater.go
+++ b/internal/boot/updater.go
@@ -9,6 +9,9 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 )
@@ -16,28 +19,31 @@ import (
 const LocalAssetsPath = "/usr/share/boot-assets"
 
 // BootUpdater manages boot partition updates (zImage, DTB, U-Boot).
+// U-Boot writes use eMMC boot partition A/B redundancy: write to the
+// inactive partition (boot0 or boot1), verify, then flip PARTITION_CONFIG.
 type BootUpdater struct {
 	mountPoint  string // e.g. /uboot
-	bootDevice  string // e.g. /dev/mmcblk3boot0
-	forceROPath string // e.g. /sys/block/mmcblk3boot0/force_ro
+	mmcDevice   string // e.g. /dev/mmcblk3 (base eMMC device)
 	dtbFile     string // e.g. librescoot-dbc.dtb
 	versionFile string // e.g. /uboot/boot-version
 	ubootSeek   int64  // 512-byte blocks to skip before writing U-Boot (default 2)
 	logger      *log.Logger
 }
 
-// New creates a BootUpdater from the given parameters.
+// bootPartRegex matches the "bootN" suffix on an eMMC boot partition device.
+var bootPartRegex = regexp.MustCompile(`boot[01]$`)
+
+// partitionConfigRegex captures the PARTITION_CONFIG hex value from
+// `mmc extcsd read` output, e.g. "PARTITION_CONFIG: 0x48".
+var partitionConfigRegex = regexp.MustCompile(`PARTITION_CONFIG:\s*0x([0-9A-Fa-f]+)`)
+
+// New creates a BootUpdater from the given parameters. bootDevice may be the
+// base eMMC device (e.g. /dev/mmcblk3) or a boot partition (/dev/mmcblk3boot0);
+// the bootN suffix, if present, is stripped.
 func New(mountPoint, bootDevice, dtbFile string, ubootSeek int64, logger *log.Logger) *BootUpdater {
-	forceROPath := ""
-	if bootDevice != "" {
-		// /dev/mmcblk3boot0 → /sys/block/mmcblk3boot0/force_ro
-		dev := strings.TrimPrefix(bootDevice, "/dev/")
-		forceROPath = "/sys/block/" + dev + "/force_ro"
-	}
 	return &BootUpdater{
 		mountPoint:  mountPoint,
-		bootDevice:  bootDevice,
-		forceROPath: forceROPath,
+		mmcDevice:   stripBootSuffix(bootDevice),
 		dtbFile:     dtbFile,
 		versionFile: mountPoint + "/boot-version",
 		ubootSeek:   ubootSeek,
@@ -45,9 +51,15 @@ func New(mountPoint, bootDevice, dtbFile string, ubootSeek int64, logger *log.Lo
 	}
 }
 
+// stripBootSuffix removes a trailing "bootN" from an eMMC device path.
+// "/dev/mmcblk3boot0" → "/dev/mmcblk3", "/dev/mmcblk3" → "/dev/mmcblk3".
+func stripBootSuffix(dev string) string {
+	return bootPartRegex.ReplaceAllString(dev, "")
+}
+
 // DetectBootDevice reads /proc/mounts, finds the device mounted at mountPoint,
-// strips the trailing partition number (p1), and appends "boot0".
-// E.g.: /dev/mmcblk3p1 → /dev/mmcblk3boot0
+// and returns the base eMMC device (with any partition suffix stripped).
+// E.g.: /dev/mmcblk3p1 mounted at /uboot → /dev/mmcblk3.
 func DetectBootDevice(mountPoint string) (string, error) {
 	f, err := os.Open("/proc/mounts")
 	if err != nil {
@@ -73,7 +85,6 @@ func detectFromReader(r io.Reader, mountPoint string) (string, error) {
 		base := device
 		if idx := strings.LastIndex(base, "p"); idx >= 0 {
 			candidate := base[:idx]
-			// Make sure what we stripped is purely digits
 			suffix := base[idx+1:]
 			allDigits := len(suffix) > 0
 			for _, ch := range suffix {
@@ -86,7 +97,7 @@ func detectFromReader(r io.Reader, mountPoint string) (string, error) {
 				base = candidate
 			}
 		}
-		return base + "boot0", nil
+		return base, nil
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -95,8 +106,8 @@ func detectFromReader(r io.Reader, mountPoint string) (string, error) {
 	return "", fmt.Errorf("no device found mounted at %s", mountPoint)
 }
 
-// CheckLocalAssets reads the version file from local boot assets baked into the rootfs.
-// Returns ("", nil) if local assets are not available.
+// CheckLocalAssets reads the version file from local boot assets baked into
+// the rootfs. Returns ("", nil) if local assets are not available.
 func (b *BootUpdater) CheckLocalAssets() (string, error) {
 	data, err := os.ReadFile(LocalAssetsPath + "/version")
 	if os.IsNotExist(err) {
@@ -165,8 +176,8 @@ func (b *BootUpdater) Apply(ctx context.Context, extractDir string) error {
 	syscall.Sync()
 
 	imxPath := extractDir + "/u-boot-dtb.imx"
-	b.logger.Printf("[boot] writing U-Boot: %s → %s", imxPath, b.bootDevice)
-	if err := b.writeUBoot(imxPath); err != nil {
+	b.logger.Printf("[boot] writing U-Boot to inactive boot partition")
+	if err := b.writeUBoot(ctx, imxPath); err != nil {
 		return fmt.Errorf("write U-Boot: %w", err)
 	}
 
@@ -224,63 +235,160 @@ func writeFileVerified(dst, src string) error {
 	return nil
 }
 
-// writeUBoot unlocks force_ro, seeks to ubootSeek*512 bytes, writes imx data,
-// reads back and verifies sha256, then re-locks force_ro.
-func (b *BootUpdater) writeUBoot(imxPath string) error {
+// writeUBoot writes the new U-Boot image to the inactive eMMC boot partition,
+// verifies via SHA256, then flips PARTITION_CONFIG to boot from it.
+// The previously active partition is left intact as a fallback.
+func (b *BootUpdater) writeUBoot(ctx context.Context, imxPath string) error {
 	imxData, err := os.ReadFile(imxPath)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", imxPath, err)
 	}
 	expectedHash := sha256sum(imxData)
 
-	// Unlock
-	if err := os.WriteFile(b.forceROPath, []byte("0\n"), 0200); err != nil {
-		return fmt.Errorf("unlock %s: %w", b.forceROPath, err)
+	active, ack, err := readPartitionConfig(ctx, b.mmcDevice)
+	if err != nil {
+		return fmt.Errorf("read partition config: %w", err)
+	}
+
+	target := inactivePartition(active)
+	targetDev := bootPartitionDevice(b.mmcDevice, target)
+	b.logger.Printf("[boot] active partition=%d, writing to inactive partition %d (%s)", active, target, targetDev)
+
+	if err := b.writeAndVerifyUBootImage(targetDev, imxData, expectedHash); err != nil {
+		return err
+	}
+
+	b.logger.Printf("[boot] flipping PARTITION_CONFIG to boot from partition %d (ack=%d)", target, ack)
+	if err := flipPartitionConfig(ctx, b.mmcDevice, target, ack); err != nil {
+		return fmt.Errorf("flip partition config to %d: %w", target, err)
+	}
+
+	b.logger.Printf("[boot] U-Boot update complete: new partition=%d, fallback partition=%d", target, active)
+	return nil
+}
+
+// writeAndVerifyUBootImage unlocks force_ro for the target boot partition,
+// writes imxData at the configured seek offset, verifies via SHA256, then
+// re-locks force_ro.
+func (b *BootUpdater) writeAndVerifyUBootImage(targetDev string, imxData []byte, expectedHash string) error {
+	forceROPath := forceROPathFor(targetDev)
+
+	if err := os.WriteFile(forceROPath, []byte("0\n"), 0200); err != nil {
+		return fmt.Errorf("unlock %s: %w", forceROPath, err)
 	}
 	defer func() {
-		if err := os.WriteFile(b.forceROPath, []byte("1\n"), 0200); err != nil {
-			b.logger.Printf("[boot] warning: failed to re-lock %s: %v", b.forceROPath, err)
+		if err := os.WriteFile(forceROPath, []byte("1\n"), 0200); err != nil {
+			b.logger.Printf("[boot] warning: failed to re-lock %s: %v", forceROPath, err)
 		}
 	}()
 
-	f, err := os.OpenFile(b.bootDevice, os.O_WRONLY, 0600)
+	f, err := os.OpenFile(targetDev, os.O_WRONLY, 0600)
 	if err != nil {
-		return fmt.Errorf("open %s: %w", b.bootDevice, err)
+		return fmt.Errorf("open %s: %w", targetDev, err)
 	}
-	defer f.Close()
 
 	offset := b.ubootSeek * 512
 	if _, err := f.Seek(offset, io.SeekStart); err != nil {
-		return fmt.Errorf("seek %s to %d: %w", b.bootDevice, offset, err)
+		f.Close()
+		return fmt.Errorf("seek %s to %d: %w", targetDev, offset, err)
 	}
 	if _, err := f.Write(imxData); err != nil {
-		return fmt.Errorf("write %s: %w", b.bootDevice, err)
+		f.Close()
+		return fmt.Errorf("write %s: %w", targetDev, err)
 	}
 	if err := f.Sync(); err != nil {
-		return fmt.Errorf("sync %s: %w", b.bootDevice, err)
+		f.Close()
+		return fmt.Errorf("sync %s: %w", targetDev, err)
 	}
 	f.Close()
 
-	// Read back and verify
-	rf, err := os.Open(b.bootDevice)
+	rf, err := os.Open(targetDev)
 	if err != nil {
-		return fmt.Errorf("open for verify %s: %w", b.bootDevice, err)
+		return fmt.Errorf("open for verify %s: %w", targetDev, err)
 	}
 	defer rf.Close()
 
 	if _, err := rf.Seek(offset, io.SeekStart); err != nil {
-		return fmt.Errorf("seek for verify %s: %w", b.bootDevice, err)
+		return fmt.Errorf("seek for verify %s: %w", targetDev, err)
 	}
 	readBack := make([]byte, len(imxData))
 	if _, err := io.ReadFull(rf, readBack); err != nil {
-		return fmt.Errorf("read back %s: %w", b.bootDevice, err)
+		return fmt.Errorf("read back %s: %w", targetDev, err)
 	}
 	actualHash := sha256sum(readBack)
 	if actualHash != expectedHash {
-		return fmt.Errorf("verify U-Boot: sha256 mismatch (expected %s, got %s)", expectedHash, actualHash)
+		return fmt.Errorf("verify U-Boot on %s: sha256 mismatch (expected %s, got %s)", targetDev, expectedHash, actualHash)
 	}
 
-	b.logger.Printf("[boot] U-Boot written and verified (%d bytes at offset %d)", len(imxData), offset)
+	b.logger.Printf("[boot] U-Boot written and verified on %s (%d bytes at offset %d)", targetDev, len(imxData), offset)
+	return nil
+}
+
+// bootPartitionDevice returns the device path for boot partition n (1 or 2).
+// /dev/mmcblk3 + 1 → /dev/mmcblk3boot0, + 2 → /dev/mmcblk3boot1.
+func bootPartitionDevice(mmcDevice string, n int) string {
+	return fmt.Sprintf("%sboot%d", mmcDevice, n-1)
+}
+
+// forceROPathFor returns the force_ro sysfs path for a boot partition device.
+// /dev/mmcblk3boot1 → /sys/block/mmcblk3boot1/force_ro.
+func forceROPathFor(bootDev string) string {
+	return "/sys/block/" + strings.TrimPrefix(bootDev, "/dev/") + "/force_ro"
+}
+
+// inactivePartition returns the boot partition number (1 or 2) opposite to
+// the currently active one. If no partition is active (active == 0) or the
+// value is unexpected, defaults to partition 1 (boot0).
+func inactivePartition(active int) int {
+	switch active {
+	case 1:
+		return 2
+	case 2:
+		return 1
+	default:
+		return 1
+	}
+}
+
+// readPartitionConfig runs `mmc extcsd read` and parses PARTITION_CONFIG.
+// Returns the active boot partition (0, 1, or 2) and the current BOOT_ACK bit.
+func readPartitionConfig(ctx context.Context, mmcDevice string) (active, ack int, err error) {
+	out, err := exec.CommandContext(ctx, "mmc", "extcsd", "read", mmcDevice).Output()
+	if err != nil {
+		return 0, 0, fmt.Errorf("mmc extcsd read %s: %w", mmcDevice, err)
+	}
+	return parsePartitionConfig(string(out))
+}
+
+// parsePartitionConfig extracts PARTITION_CONFIG from `mmc extcsd read` output
+// and returns the active partition (bits 5:3) and BOOT_ACK (bit 6).
+func parsePartitionConfig(output string) (active, ack int, err error) {
+	m := partitionConfigRegex.FindStringSubmatch(output)
+	if m == nil {
+		return 0, 0, fmt.Errorf("PARTITION_CONFIG not found in mmc extcsd output")
+	}
+	val, err := strconv.ParseUint(m[1], 16, 8)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse PARTITION_CONFIG value %q: %w", m[1], err)
+	}
+	active = int((val >> 3) & 0x07)
+	ack = int((val >> 6) & 0x01)
+	return active, ack, nil
+}
+
+// flipPartitionConfig invokes `mmc bootpart enable` to set the active boot
+// partition. newPart is 1 (boot0) or 2 (boot1). ack is preserved from the
+// current PARTITION_CONFIG state.
+func flipPartitionConfig(ctx context.Context, mmcDevice string, newPart, ack int) error {
+	if newPart != 1 && newPart != 2 {
+		return fmt.Errorf("invalid boot partition %d (must be 1 or 2)", newPart)
+	}
+	cmd := exec.CommandContext(ctx, "mmc", "bootpart", "enable",
+		strconv.Itoa(newPart), strconv.Itoa(ack), mmcDevice)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("mmc bootpart enable %d %d %s: %w (output: %s)", newPart, ack, mmcDevice, err, strings.TrimSpace(string(out)))
+	}
 	return nil
 }
 

--- a/internal/boot/updater_test.go
+++ b/internal/boot/updater_test.go
@@ -24,7 +24,7 @@ proc /proc proc rw 0 0
 tmpfs /tmp tmpfs rw 0 0
 `,
 			mountPoint: "/uboot",
-			want:       "/dev/mmcblk3boot0",
+			want:       "/dev/mmcblk3",
 		},
 		{
 			name: "mmcblk1p1 at /uboot",
@@ -32,7 +32,7 @@ tmpfs /tmp tmpfs rw 0 0
 /dev/mmcblk1p2 / ext4 rw 0 0
 `,
 			mountPoint: "/uboot",
-			want:       "/dev/mmcblk1boot0",
+			want:       "/dev/mmcblk1",
 		},
 		{
 			name: "mount point not found",
@@ -46,14 +46,12 @@ tmpfs /tmp tmpfs rw 0 0
 			mounts: `/dev/sda /uboot vfat rw 0 0
 `,
 			mountPoint: "/uboot",
-			// /dev/sda has no 'p' partition suffix so base stays as /dev/sda
-			want: "/dev/sdaboot0",
+			want:       "/dev/sda",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Write fake /proc/mounts to a temp file
 			f, err := os.CreateTemp(t.TempDir(), "mounts")
 			if err != nil {
 				t.Fatal(err)
@@ -63,9 +61,6 @@ tmpfs /tmp tmpfs rw 0 0
 			}
 			f.Close()
 
-			// Patch the function to use our temp file by monkey-patching Open
-			// Since we can't easily mock os.Open, we use an internal helper instead.
-			// For the test, we use detectBootDeviceFromFile.
 			got, err := detectBootDeviceFromFile(f.Name(), tt.mountPoint)
 			if tt.wantErr {
 				if err == nil {
@@ -80,6 +75,150 @@ tmpfs /tmp tmpfs rw 0 0
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestStripBootSuffix(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"/dev/mmcblk3boot0", "/dev/mmcblk3"},
+		{"/dev/mmcblk3boot1", "/dev/mmcblk3"},
+		{"/dev/mmcblk1boot0", "/dev/mmcblk1"},
+		{"/dev/mmcblk3", "/dev/mmcblk3"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := stripBootSuffix(tt.in); got != tt.want {
+			t.Errorf("stripBootSuffix(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParsePartitionConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantActive int
+		wantAck    int
+		wantErr    bool
+	}{
+		{
+			name:       "boot0 active with ack",
+			output:     "Boot configuration bytes [PARTITION_CONFIG: 0x48]\n",
+			wantActive: 1,
+			wantAck:    1,
+		},
+		{
+			name:       "boot1 active with ack",
+			output:     "Boot configuration bytes [PARTITION_CONFIG: 0x50]\n",
+			wantActive: 2,
+			wantAck:    1,
+		},
+		{
+			name:       "boot0 active no ack",
+			output:     "Boot configuration bytes [PARTITION_CONFIG: 0x08]\n",
+			wantActive: 1,
+			wantAck:    0,
+		},
+		{
+			name:       "no boot partition enabled",
+			output:     "Boot configuration bytes [PARTITION_CONFIG: 0x00]\n",
+			wantActive: 0,
+			wantAck:    0,
+		},
+		{
+			name:       "user area enabled",
+			output:     "Boot configuration bytes [PARTITION_CONFIG: 0x38]\n",
+			wantActive: 7,
+			wantAck:    0,
+		},
+		{
+			name:       "older label format",
+			output:     "Boot Area Partition [PARTITION_CONFIG: 0x48]\n",
+			wantActive: 1,
+			wantAck:    1,
+		},
+		{
+			name:       "embedded in larger extcsd dump",
+			output:     "...\nBoot configuration: B_SIZE_MULT: 0x10\nBoot configuration bytes [PARTITION_CONFIG: 0x48]\nBoot bus Conditions [BOOT_BUS_CONDITIONS: 0x00]\n...",
+			wantActive: 1,
+			wantAck:    1,
+		},
+		{
+			name:    "missing",
+			output:  "Extended CSD rev 1.7 (MMC 5.0)\n",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			active, ack, err := parsePartitionConfig(tt.output)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got active=%d ack=%d", active, ack)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if active != tt.wantActive {
+				t.Errorf("active = %d, want %d", active, tt.wantActive)
+			}
+			if ack != tt.wantAck {
+				t.Errorf("ack = %d, want %d", ack, tt.wantAck)
+			}
+		})
+	}
+}
+
+func TestInactivePartition(t *testing.T) {
+	tests := []struct {
+		active, want int
+	}{
+		{0, 1},
+		{1, 2},
+		{2, 1},
+		{7, 1},
+	}
+	for _, tt := range tests {
+		if got := inactivePartition(tt.active); got != tt.want {
+			t.Errorf("inactivePartition(%d) = %d, want %d", tt.active, got, tt.want)
+		}
+	}
+}
+
+func TestBootPartitionDevice(t *testing.T) {
+	tests := []struct {
+		mmc  string
+		n    int
+		want string
+	}{
+		{"/dev/mmcblk3", 1, "/dev/mmcblk3boot0"},
+		{"/dev/mmcblk3", 2, "/dev/mmcblk3boot1"},
+		{"/dev/mmcblk1", 1, "/dev/mmcblk1boot0"},
+		{"/dev/mmcblk1", 2, "/dev/mmcblk1boot1"},
+	}
+	for _, tt := range tests {
+		if got := bootPartitionDevice(tt.mmc, tt.n); got != tt.want {
+			t.Errorf("bootPartitionDevice(%q, %d) = %q, want %q", tt.mmc, tt.n, got, tt.want)
+		}
+	}
+}
+
+func TestForceROPathFor(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"/dev/mmcblk3boot0", "/sys/block/mmcblk3boot0/force_ro"},
+		{"/dev/mmcblk3boot1", "/sys/block/mmcblk3boot1/force_ro"},
+		{"/dev/mmcblk1boot1", "/sys/block/mmcblk1boot1/force_ro"},
+	}
+	for _, tt := range tests {
+		if got := forceROPathFor(tt.in); got != tt.want {
+			t.Errorf("forceROPathFor(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 }
 
@@ -112,7 +251,6 @@ func TestGetInstalledVersion(t *testing.T) {
 		versionFile: filepath.Join(dir, "boot-version"),
 	}
 
-	// Missing file → ""
 	ver, err := b.GetInstalledVersion()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -121,7 +259,6 @@ func TestGetInstalledVersion(t *testing.T) {
 		t.Errorf("expected empty version, got %q", ver)
 	}
 
-	// Write a version
 	if err := os.WriteFile(b.versionFile, []byte("nightly-20260301T013104\n"), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mender/install_test.go
+++ b/internal/mender/install_test.go
@@ -63,7 +63,7 @@ func TestCommitResult_ExitCodes(t *testing.T) {
 
 func TestInconsistentSuffix(t *testing.T) {
 	testCases := []struct {
-		artifact      string
+		artifact       string
 		isInconsistent bool
 	}{
 		{"release-nightly-20251211T024757", false},

--- a/internal/mender/mender.go
+++ b/internal/mender/mender.go
@@ -11,10 +11,10 @@ import (
 
 // Manager combines download and installation functionality for Mender updates
 type Manager struct {
-	downloader    *Downloader
-	installer     *Installer
-	deltaApplier  *DeltaApplier
-	logger        *log.Logger
+	downloader   *Downloader
+	installer    *Installer
+	deltaApplier *DeltaApplier
+	logger       *log.Logger
 }
 
 // NewManager creates a new Mender manager with the specified download directory

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -32,9 +32,9 @@ func TestUpdateCheckMutex_PreventsConcurrentChecks(t *testing.T) {
 
 func TestCorruptionErrorDetection(t *testing.T) {
 	testCases := []struct {
-		name           string
-		errorMsg       string
-		isCorruption   bool
+		name         string
+		errorMsg     string
+		isCorruption bool
 	}{
 		{
 			name:         "gzip decompression error",


### PR DESCRIPTION
## Summary

U-Boot updates previously wrote directly to the active boot partition
(`mmcblkXboot0`) with no fallback. A power loss mid-write bricked the
device and needed physical access to reflash.

This writes the new U-Boot to the *inactive* boot partition (boot0 or
boot1, whichever isn't currently active), SHA256-verifies, then flips
the eMMC `PARTITION_CONFIG` register via `mmc bootpart enable`. The
previously active partition stays intact as a fallback.

## Changes

- `BootUpdater` now stores the base eMMC device (`/dev/mmcblkX`) and
  derives per-partition device paths and `force_ro` sysfs paths at
  write time
- `readPartitionConfig` parses `mmc extcsd read` output to find the
  active partition (bits 5:3) and `BOOT_ACK` bit
- `flipPartitionConfig` shells out to
  `mmc bootpart enable <N> <ack> /dev/mmcblkX`
- Unit tests cover `PARTITION_CONFIG` parsing, partition mapping,
  boot device derivation, `force_ro` path resolution

## Requires

`mmc-utils` on the target. Added to the MDB and DBC images in
librescoot/meta-librescoot#37.

## Not covered here

- Hardware testing on MDB and DBC still needs to happen
- An image that passes SHA256 but has a runtime bug would still flip
  and leave the device unable to boot. That case needs an env-level
  watchdog, handled in the stacked PR #16

Refs librescoot/librescoot#23